### PR TITLE
Fix typo: branches array was missing a comma

### DIFF
--- a/contracts/NTDaoGene.sol
+++ b/contracts/NTDaoGene.sol
@@ -35,7 +35,7 @@ contract NTDaoGene is Ownable {
         "Rabbit",  //3
         "Dragon",  //4        
         "Snake",   //5
-        "Horse"    //6
+        "Horse",   //6
         "Goat",    //7
         "Monkey",  //8
         "Rooster", //9


### PR DESCRIPTION
This bug resulted the wrong branch names when minting an NFT. See https://testnets.opensea.io/assets/baobab/0xdbbabb59cbb6101effa83cbc11e3a760ecf32da6/8